### PR TITLE
Config paged reader

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -37,7 +37,7 @@ func Example() {
 	image, _ := os.Open("testdata/filesystem/ntfs.dd")
 
 	// parse the file system
-	fsys, _ := ntfs.New(image, 0, 0)
+	fsys, _ := ntfs.New(image)
 
 	// get filenames
 	entries, _ := fs.ReadDir(fsys, ".")

--- a/example_test.go
+++ b/example_test.go
@@ -37,7 +37,7 @@ func Example() {
 	image, _ := os.Open("testdata/filesystem/ntfs.dd")
 
 	// parse the file system
-	fsys, _ := ntfs.New(image)
+	fsys, _ := ntfs.New(image, 0, 0)
 
 	// get filenames
 	entries, _ := fs.ReadDir(fsys, ".")

--- a/ntfs/ntfs.go
+++ b/ntfs/ntfs.go
@@ -38,24 +38,24 @@ import (
 )
 
 var (
-    DefaultPageSize = 1024*1024
-    DefaultCacheSize = 100*1024*1024
+	DefaultPageSize  = 1024 * 1024
+	DefaultCacheSize = 100 * 1024 * 1024
 )
 
 func checkPageSizeAndCacheSize(pageSize, cacheSize int) (int, int) {
-    if pageSize <= 0 {
-        pageSize = DefaultPageSize
-    }
+	if pageSize <= 0 {
+		pageSize = DefaultPageSize
+	}
 
-    if cacheSize <= 0 {
-        cacheSize = DefaultCacheSize
-    }
-    return pageSize, cacheSize
+	if cacheSize <= 0 {
+		cacheSize = DefaultCacheSize
+	}
+	return pageSize, cacheSize
 }
 
 // New creates a new ntfs FS.
 func New(r io.ReaderAt, pageSize, cacheSize int) (fs *FS, err error) {
-    pageSize, cacheSize = checkPageSizeAndCacheSize(pageSize, cacheSize)
+	pageSize, cacheSize = checkPageSizeAndCacheSize(pageSize, cacheSize)
 	defer func() {
 		if r := recover(); r != nil {
 			err = errors.New("error parsing file system as NTFS")
@@ -77,7 +77,7 @@ type FS struct {
 // Open opens a file for reading.
 func (fsys *FS) Open(name string) (item fs.File, err error) {
 	valid := fs.ValidPath(name)
-	if !valid || strings.Contains(name, `\`){
+	if !valid || strings.Contains(name, `\`) {
 		return nil, fmt.Errorf("path %s invalid", name)
 	}
 	name = "/" + name

--- a/ntfs/ntfs.go
+++ b/ntfs/ntfs.go
@@ -37,6 +37,11 @@ import (
 	"www.velocidex.com/golang/go-ntfs/parser"
 )
 
+var (
+    DefaultPageSize = 1024*1024
+    DefaultCacheSize = 100*1024*1024
+)
+
 // New creates a new ntfs FS.
 func New(r io.ReaderAt) (fs *FS, err error) {
 	defer func() {
@@ -45,6 +50,21 @@ func New(r io.ReaderAt) (fs *FS, err error) {
 		}
 	}()
 	reader, err := parser.NewPagedReader(r, 1024*1024, 100*1024*1024)
+	if err != nil {
+		return nil, err
+	}
+	ntfsCtx, err := parser.GetNTFSContext(reader, 0)
+	return &FS{ntfsCtx: ntfsCtx}, err
+}
+
+// New2 creates a new ntfs FS.
+func New2(r io.ReaderAt, pagesize, cacheSize int) (fs *FS, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New("error parsing file system as NTFS")
+		}
+	}()
+	reader, err := parser.NewPagedReader(r, int64(pagesize), cacheSize)
 	if err != nil {
 		return nil, err
 	}

--- a/ntfs/ntfs.go
+++ b/ntfs/ntfs.go
@@ -37,31 +37,36 @@ import (
 	"www.velocidex.com/golang/go-ntfs/parser"
 )
 
-var (
-	DefaultPageSize  = 1024 * 1024
-	DefaultCacheSize = 100 * 1024 * 1024
+const (
+	defaultPageSize  = 1024 * 1024
+	defaultCacheSize = 100 * 1024 * 1024
 )
 
-func checkPageSizeAndCacheSize(pageSize, cacheSize int) (int, int) {
+func checkPageSizeAndCacheSize(pageSize int64, cacheSize int) (int64, int) {
 	if pageSize <= 0 {
-		pageSize = DefaultPageSize
+		pageSize = defaultPageSize
 	}
 
 	if cacheSize <= 0 {
-		cacheSize = DefaultCacheSize
+		cacheSize = defaultCacheSize
 	}
 	return pageSize, cacheSize
 }
 
 // New creates a new ntfs FS.
-func New(r io.ReaderAt, pageSize, cacheSize int) (fs *FS, err error) {
+func New(r io.ReaderAt) (fs *FS, err error) {
+	return NewWithSize(r, defaultPageSize, defaultCacheSize)
+}
+
+// NewWithSize creates a new ntfs FS with specific pageSize and cacheSize.
+func NewWithSize(r io.ReaderAt, pageSize int64, cacheSize int) (fs *FS, err error) {
 	pageSize, cacheSize = checkPageSizeAndCacheSize(pageSize, cacheSize)
 	defer func() {
 		if r := recover(); r != nil {
 			err = errors.New("error parsing file system as NTFS")
 		}
 	}()
-	reader, err := parser.NewPagedReader(r, int64(pageSize), cacheSize)
+	reader, err := parser.NewPagedReader(r, pageSize, cacheSize)
 	if err != nil {
 		return nil, err
 	}

--- a/ntfs/ntfs.go
+++ b/ntfs/ntfs.go
@@ -42,29 +42,26 @@ var (
     DefaultCacheSize = 100*1024*1024
 )
 
-// New creates a new ntfs FS.
-func New(r io.ReaderAt) (fs *FS, err error) {
-	defer func() {
-		if r := recover(); r != nil {
-			err = errors.New("error parsing file system as NTFS")
-		}
-	}()
-	reader, err := parser.NewPagedReader(r, 1024*1024, 100*1024*1024)
-	if err != nil {
-		return nil, err
-	}
-	ntfsCtx, err := parser.GetNTFSContext(reader, 0)
-	return &FS{ntfsCtx: ntfsCtx}, err
+func checkPageSizeAndCacheSize(pageSize, cacheSize int) (int, int) {
+    if pageSize <= 0 {
+        pageSize = DefaultPageSize
+    }
+
+    if cacheSize <= 0 {
+        cacheSize = DefaultCacheSize
+    }
+    return pageSize, cacheSize
 }
 
-// New2 creates a new ntfs FS.
-func New2(r io.ReaderAt, pagesize, cacheSize int) (fs *FS, err error) {
+// New creates a new ntfs FS.
+func New(r io.ReaderAt, pageSize, cacheSize int) (fs *FS, err error) {
+    pageSize, cacheSize = checkPageSizeAndCacheSize(pageSize, cacheSize)
 	defer func() {
 		if r := recover(); r != nil {
 			err = errors.New("error parsing file system as NTFS")
 		}
 	}()
-	reader, err := parser.NewPagedReader(r, int64(pagesize), cacheSize)
+	reader, err := parser.NewPagedReader(r, int64(pageSize), cacheSize)
 	if err != nil {
 		return nil, err
 	}

--- a/ntfs/ntfs_test.go
+++ b/ntfs/ntfs_test.go
@@ -45,7 +45,7 @@ func TestFS(t *testing.T) {
 	}
 	r := bytes.NewReader(b)
 
-	fsys, err := New(r, 0, 0)
+	fsys, err := New(r)
 	if err != nil {
 		t.Error(err)
 	}
@@ -91,7 +91,7 @@ func Test_NTFSImage(t *testing.T) {
 	tests["file2Test"].InfoModTime = time.Date(2019, time.August, 21, 17, 40, 04, 0, time.UTC)
 	tests["file2Test"].InfoMode = 0
 
-	fslibtest.RunTest(t, "NTFS", "testdata/filesystem/ntfs.dd", func(f fsio.ReadSeekerAt) (fs.FS, error) { return New(f, 0, 0) }, tests)
+	fslibtest.RunTest(t, "NTFS", "testdata/filesystem/ntfs.dd", func(f fsio.ReadSeekerAt) (fs.FS, error) { return New(f) }, tests)
 }
 
 func TestNew(t *testing.T) {
@@ -109,7 +109,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotFs, err := New(tt.args.r, 0, 0)
+			gotFs, err := New(tt.args.r)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/ntfs/ntfs_test.go
+++ b/ntfs/ntfs_test.go
@@ -39,7 +39,7 @@ import (
 )
 
 func TestFS(t *testing.T) {
-	b , err := os.ReadFile("../testdata/filesystem/ntfs.dd")
+	b, err := os.ReadFile("../testdata/filesystem/ntfs.dd")
 	if err != nil {
 		t.Error(err)
 	}

--- a/ntfs/ntfs_test.go
+++ b/ntfs/ntfs_test.go
@@ -45,7 +45,7 @@ func TestFS(t *testing.T) {
 	}
 	r := bytes.NewReader(b)
 
-	fsys, err := New(r)
+	fsys, err := New(r, 0, 0)
 	if err != nil {
 		t.Error(err)
 	}
@@ -91,7 +91,7 @@ func Test_NTFSImage(t *testing.T) {
 	tests["file2Test"].InfoModTime = time.Date(2019, time.August, 21, 17, 40, 04, 0, time.UTC)
 	tests["file2Test"].InfoMode = 0
 
-	fslibtest.RunTest(t, "NTFS", "testdata/filesystem/ntfs.dd", func(f fsio.ReadSeekerAt) (fs.FS, error) { return New(f) }, tests)
+	fslibtest.RunTest(t, "NTFS", "testdata/filesystem/ntfs.dd", func(f fsio.ReadSeekerAt) (fs.FS, error) { return New(f, 0, 0) }, tests)
 }
 
 func TestNew(t *testing.T) {
@@ -109,7 +109,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotFs, err := New(tt.args.r)
+			gotFs, err := New(tt.args.r, 0, 0)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/systemfs/system_fs_test.go
+++ b/systemfs/system_fs_test.go
@@ -23,13 +23,14 @@
 package systemfs
 
 import (
-	"github.com/forensicanalysis/fslib"
 	"io"
 	"io/fs"
 	"os"
 	"runtime"
 	"testing"
 	"testing/fstest"
+
+	"github.com/forensicanalysis/fslib"
 )
 
 func TestFS(t *testing.T) {
@@ -52,8 +53,6 @@ func TestFS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-
-
 	if err := fstest.TestFS(fsys, "systemfs.go"); err != nil {
 		t.Fatal(err)
 	}
@@ -67,8 +66,8 @@ func Test_LocalNTFS(t *testing.T) {
 		}
 	}
 
-	tests := []struct{
-		path string
+	tests := []struct {
+		path   string
 		header string
 	}{
 		{"C/$MFT", "FILE"},
@@ -97,7 +96,7 @@ func Test_LocalNTFS(t *testing.T) {
 
 				header := make([]byte, len(test.header))
 				n, err := file.Read(header)
-				if err != nil && err != io.EOF{
+				if err != nil && err != io.EOF {
 					t.Errorf("read error %s", err)
 				}
 				if n != len(test.header) {

--- a/systemfs/systemfs.go
+++ b/systemfs/systemfs.go
@@ -110,7 +110,7 @@ func (systemfs *FS) NTFSOpen(name string) (fs.File, func() error, error) {
 		return nil, nil, fmt.Errorf("ntfs base open failed: %w", err)
 	}
 
-	lowLevelFS, err := ntfs.New(base)
+	lowLevelFS, err := ntfs.New2(base, 1024*1024, 100*1024*1024)
 	if err != nil {
 		base.Close() // nolint:errcheck
 		return nil, nil, fmt.Errorf("ntfs creation failed: %w", err)

--- a/systemfs/systemfs.go
+++ b/systemfs/systemfs.go
@@ -70,13 +70,13 @@ func newFS() (fs.FS, error) {
 // FS implements a read-only file system for all operating systems.
 type FS struct {
 	ntfsPartitions []string
-    cacheSize int
-    pageSize int
+	cacheSize      int
+	pageSize       int
 }
 
 func (systemfs *FS) setPageAndCacheSize(pageSize, cacheSize int) {
-    systemfs.cacheSize = cacheSize
-    systemfs.pageSize = pageSize
+	systemfs.cacheSize = cacheSize
+	systemfs.pageSize = pageSize
 }
 
 // Open opens a file for reading.

--- a/systemfs/systemfs.go
+++ b/systemfs/systemfs.go
@@ -37,13 +37,8 @@ import (
 )
 
 // New creates a new system FS.
-func New(pageSize, cacheSize int) (fs.FS, error) {
-    ourFS, err := newFS()
-    if err != nil {
-        return ourFS, err
-    }
-
-	return ourFS, nil
+func New() (fs.FS, error) {
+	return newFS()
 }
 
 func newFS() (fs.FS, error) {
@@ -122,7 +117,7 @@ func (systemfs *FS) NTFSOpen(name string) (fs.File, func() error, error) {
 		return nil, nil, fmt.Errorf("ntfs base open failed: %w", err)
 	}
 
-	lowLevelFS, err := ntfs.New2(base, 1024*1024, 1*1024*1024)
+	lowLevelFS, err := ntfs.New(base, 0, 0)
 	if err != nil {
 		base.Close() // nolint:errcheck
 		return nil, nil, fmt.Errorf("ntfs creation failed: %w", err)
@@ -169,7 +164,7 @@ func (systemfs *FS) Stat(name string) (info fs.FileInfo, err error) {
 		return nil, fmt.Errorf("ntfs base open failed: %w", err)
 	}
 
-	lowLevelFS, err := ntfs.New(base)
+	lowLevelFS, err := ntfs.New(base, 0, 0)
 	if err != nil {
 		base.Close() // nolint:errcheck
 		return info, fmt.Errorf("ntfs creation failed: %w", err)

--- a/systemfs/systemfs.go
+++ b/systemfs/systemfs.go
@@ -37,8 +37,13 @@ import (
 )
 
 // New creates a new system FS.
-func New() (fs.FS, error) {
-	return newFS()
+func New(pageSize, cacheSize int) (fs.FS, error) {
+    ourFS, err := newFS()
+    if err != nil {
+        return ourFS, err
+    }
+
+	return ourFS, nil
 }
 
 func newFS() (fs.FS, error) {
@@ -70,6 +75,13 @@ func newFS() (fs.FS, error) {
 // FS implements a read-only file system for all operating systems.
 type FS struct {
 	ntfsPartitions []string
+    cacheSize int
+    pageSize int
+}
+
+func (systemfs *FS) setPageAndCacheSize(pageSize, cacheSize int) {
+    systemfs.cacheSize = cacheSize
+    systemfs.pageSize = pageSize
 }
 
 // Open opens a file for reading.
@@ -110,7 +122,7 @@ func (systemfs *FS) NTFSOpen(name string) (fs.File, func() error, error) {
 		return nil, nil, fmt.Errorf("ntfs base open failed: %w", err)
 	}
 
-	lowLevelFS, err := ntfs.New2(base, 1024*1024, 100*1024*1024)
+	lowLevelFS, err := ntfs.New2(base, 1024*1024, 1*1024*1024)
 	if err != nil {
 		base.Close() // nolint:errcheck
 		return nil, nil, fmt.Errorf("ntfs creation failed: %w", err)


### PR DESCRIPTION
While performing a collection via `artifactcollector` I noticed high memory usage during runtime. That was captured here: https://github.com/forensicanalysis/artifactcollector/issues/141

It was mentioned in an issue [here](https://github.com/Velocidex/go-ntfs/issues/19) that the implications of memory usage were not known. So, I performed some testing on my own with aid of this PR. I believe the root cause of the `artifactcollector` issue that I reported to be this line: https://github.com/forensicanalysis/fslib/blob/62da1f4949b5c5210a23c1b472233bf2af2eafc1/ntfs/ntfs.go#L47

Here are two different tests using code from this PR: 
![image](https://user-images.githubusercontent.com/21049232/127406002-8fb830c1-358d-4db7-994f-10ebe86a20f0.png)

The two different `pageSize` and `cacheSize` values have a huge impact on memory usage (and execution time as well). Making that configurable would be a huge win in my opinion.

Here is the code to produce the above output: 

```go
package main

import (
	"flag"
	"io"
	"log"
	"os"
	"runtime"
	"time"

	"github.com/forensicanalysis/fslib/ntfs"
)

var (
	pageSize  int
	cacheSize int
	artifact  string
)

func main() {
	start := time.Now()
	flag.IntVar(&pageSize, "pagesize", 0, "page size in bytes for NTFS reader")
	flag.IntVar(&cacheSize, "cachesize", 0, "cache size in bytes")
	flag.StringVar(&artifact, "artifact", "", "artifact to be collected")
	flag.Parse()

	f, err := os.Open(`\\.\C:`)
	if err != nil {
		log.Fatalf("reading PHYSICALDRIVE0: %v\n", err)
	}

	fsys, err := ntfs.New(f, pageSize, cacheSize)
	//fsys, err := ntfs.New(f)
	if err != nil {
		log.Fatalf("getting ntfs.New2 reader %v\n", err)
	}

	log.Printf("low level open %s", artifact[2:])
	item, err := fsys.Open(artifact[2:])
	if err != nil {
		log.Fatalf("fsys.Open(...): %v\n", err)
	}
	output, _ := os.Create("out.bin")

	nb, err := io.Copy(output, item)
	PrintMemUsage()
	if err != nil {
		log.Fatalf("io.Copy(): %v\n", err)
	}
	log.Printf("copied %d bytes from %s to %s\n", nb, artifact, output.Name())
	log.Printf("copied %s (%d bytes) in %f secs\n", artifact, nb, time.Since(start).Seconds())
}

// PrintMemUsage outputs the current, total and OS memory being used. As well as the number
// of garage collection cycles completed.
func PrintMemUsage() {
	var m runtime.MemStats
	runtime.ReadMemStats(&m)
	// For info on each, see: https://golang.org/pkg/runtime/#MemStats
	log.Printf("Alloc = %v MiB", bToMb(m.Alloc))
	log.Printf("\tTotalAlloc = %v MiB", bToMb(m.TotalAlloc))
	log.Printf("\tSys = %v MiB", bToMb(m.Sys))
	log.Printf("\tNumGC = %v\n", m.NumGC)
}

func bToMb(b uint64) uint64 {
	return b / 1024 / 1024
}
```